### PR TITLE
Bump to version 1.1

### DIFF
--- a/info.json
+++ b/info.json
@@ -5,7 +5,7 @@
 	"author": "Kizrak",
 	"contact": "",
 	"homepage": "https://github.com/abaines/Resource-Marker",
-	"factorio_version": "1.0",
+	"factorio_version": "1.1",
 	"dependencies": [
 		"base >= 1.0.0",
 		"? rso-mod"


### PR DESCRIPTION
Currently doesn't work with 1.1 simply because of the `factorio_version` mismatch.