### PR TITLE
Let's the user specify exceptions when clearing all map tags

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -609,7 +609,7 @@ end
 
 local function reset_map_tags_and_data(event)
 	local player = game.players[event.player_index]
-	clear_map_tags_and_data(event)
+	clear_map_tags_and_data(nil)
 
 	for _, force in pairs(game.forces) do
 		for _, surface in pairs(game.surfaces) do

--- a/control.lua
+++ b/control.lua
@@ -536,33 +536,54 @@ local function chart_generated_chunks(event)
 	player.print("Revealing all generated chunks to your force.")
 end
 
-
-
-
 local function clear_map_tags_and_data(event)
 	global[_RESOURCE_MAP_] = {}
 	loggedMissingResources = {}
 	lastLoggedTagCount = {}
-
+	local parameters = event.parameter
+	
+	local tag_exceptions = {}
+	local i = 0 -- used to ignore first parameter entry
+	for parameter in string.gmatch(parameters, "([^,]+)") do
+		if i ~= 0 then tag_exceptions[parameter] = true end -- if not first parameter entry then insert key into lookup table
+		i = i + 1
+	end
+	
+	local player = game.players[event.player_index]
+	
+	--local keys={}
+	--for key,_ in pairs(tag_exceptions) do
+	--	player.print(key)
+	--end
+	
 	for _, surface in pairs(game.surfaces) do
 		for _, force in pairs(game.forces) do
 			for _,tag in pairs(force.find_chart_tags(surface)) do
-				tag.destroy()
+				if i ~= 1 then -- if user inputted atleast 1 tag exception
+					local tag_length = string.len(tag.text) -- find length of tag name
+					local cutoff,_ = string.find(string.reverse(tag.text), " ", 1, true) -- find index of the last space bar.
+					if tag_exceptions[string.sub(tag.text, 1, tag_length - cutoff)] == nil then -- if tag.text isn't in the lookup table
+						tag.destroy()
+					end
+				else
+					tag.destroy()
+				end
 			end
 		end
 	end
 
-	if event then
-		local player = game.players[event.player_index]
-		player.print("Removed all map labels and cleared mod data.")
-	end
+	--for _,tag_exception in pairs(tag_exceptions) do player.print(tag_exception .. "(string comparison)") end
+	--if event then
+	--	local player = game.players[event.player_index]
+	--	player.print("Removed all map labels and cleared mod data.")
+	--end
 end
 
 
 
 local function reset_map_tags_and_data(event)
 	local player = game.players[event.player_index]
-	clear_map_tags_and_data(nil)
+	clear_map_tags_and_data(event)
 
 	for _, force in pairs(game.forces) do
 		for _, surface in pairs(game.surfaces) do

--- a/control.lua
+++ b/control.lua
@@ -600,7 +600,7 @@ local function clear_map_tags_and_data(event,tag_exceptions)
 				player.print("   " .. tag_exp)
 			end
 		else
-			player.print("Removed all map labels and cleared mod data")
+			player.print("Removed all map labels and cleared mod data.")
 		end
 	end
 end

--- a/control.lua
+++ b/control.lua
@@ -566,7 +566,7 @@ local function _get_tag_exceptions(event)
 		if i ~= 0 then -- if not first parameter entry then insert key into lookup table
 			trimmed = parameter:match('^%s*(.-)%s*$'):lower()
 			tag_exceptions[trimmed] = true
-		 end
+		end
 		i = i + 1
 	end
 

--- a/control.lua
+++ b/control.lua
@@ -21,7 +21,7 @@ local function table_length(tb)
 	-- table array size length count
 	assert(type(tb)=='table')
 
-	count = 0
+	local count = 0
 	for k in pairs(tb) do
 		count = count + 1
 	end
@@ -564,8 +564,8 @@ local function _get_tag_exceptions(event)
 
 	for parameter in string.gmatch(parameters, "([^,]+)") do
 		if i ~= 0 then -- if not first parameter entry then insert key into lookup table
-			trimmed = parameter:match('^%s*(.-)%s*$'):lower()
-			tag_exceptions[trimmed] = true
+			local cleaned_param = parameter:match('^%s*(.-)%s*$'):lower()
+			tag_exceptions[cleaned_param] = true
 		end
 		i = i + 1
 	end
@@ -575,9 +575,6 @@ end
 
 local function clear_map_tags_and_data(event,tag_exceptions)
 	global[_RESOURCE_MAP_] = {}
-
-	local loggedMissingResources = {}
-	local lastLoggedTagCount = {}
 
 	tag_exceptions = tag_exceptions or {}
 

--- a/control.lua
+++ b/control.lua
@@ -565,7 +565,6 @@ local function clear_map_tags_and_data(event)
 		end
 	end
 
-	--for _,tag_exception in pairs(tag_exceptions) do player.print(tag_exception .. "(string comparison)") end
 	--if event then
 	--	local player = game.players[event.player_index]
 	--	player.print("Removed all map labels and cleared mod data.")

--- a/control.lua
+++ b/control.lua
@@ -549,13 +549,6 @@ local function clear_map_tags_and_data(event)
 		i = i + 1
 	end
 	
-	local player = game.players[event.player_index]
-	
-	--local keys={}
-	--for key,_ in pairs(tag_exceptions) do
-	--	player.print(key)
-	--end
-	
 	for _, surface in pairs(game.surfaces) do
 		for _, force in pairs(game.forces) do
 			for _,tag in pairs(force.find_chart_tags(surface)) do
@@ -565,7 +558,7 @@ local function clear_map_tags_and_data(event)
 					if tag_exceptions[string.sub(tag.text, 1, tag_length - cutoff)] == nil then -- if tag.text isn't in the lookup table
 						tag.destroy()
 					end
-				else
+				else -- if user didn't input any tag exceptions
 					tag.destroy()
 				end
 			end

--- a/control.lua
+++ b/control.lua
@@ -671,7 +671,7 @@ local function unifiedCommandHandler(event)
 
 	elseif string.find(parameter,"delete") then
 		player.print("   delete -- Remove all map labels and clear mod data.",darkRed)
-		tag_exceptions = _get_tag_exceptions(event)
+		local tag_exceptions = _get_tag_exceptions(event)
 		clear_map_tags_and_data(event,tag_exceptions)
 
 	elseif string.find(parameter,"log") then

--- a/control.lua
+++ b/control.lua
@@ -548,9 +548,10 @@ local function chart_generated_chunks(event)
 end
 
 local function _get_ore_name(tag)
-	local tag_length = string.len(tag.text) -- find length of tag name
-	local cutoff,_ = string.find(string.reverse(tag.text), " ", 1, true) -- find index of the last space bar.
-	local tag_ore_name = string.sub(tag.text, 1, tag_length - cutoff)
+	local text = tag.text
+	local tag_length = string.len(text) -- find length of tag name
+	local cutoff,_ = string.find(string.reverse(text), " ", 1, true) -- find index of the last space
+	local tag_ore_name = string.sub(text, 1, tag_length - cutoff)
 
 	return tag_ore_name
 end
@@ -560,8 +561,12 @@ local function _get_tag_exceptions(event)
 
 	local tag_exceptions = {}
 	local i = 0 -- used to ignore first parameter entry
+
 	for parameter in string.gmatch(parameters, "([^,]+)") do
-		if i ~= 0 then tag_exceptions[parameter] = true end -- if not first parameter entry then insert key into lookup table
+		if i ~= 0 then -- if not first parameter entry then insert key into lookup table
+			trimmed = parameter:match('^%s*(.-)%s*$'):lower()
+			tag_exceptions[trimmed] = true
+		 end
 		i = i + 1
 	end
 
@@ -579,8 +584,8 @@ local function clear_map_tags_and_data(event,tag_exceptions)
 	for _, surface in pairs(game.surfaces) do
 		for _, force in pairs(game.forces) do
 			for _,tag in pairs(force.find_chart_tags(surface)) do
-				local tag_ore_name = _get_ore_name(tag)
-				if tag_exceptions[tag_ore_name] == nil then -- if tag.text isn't in the lookup table
+				local tag_ore_name = _get_ore_name(tag):lower()
+				if tag_exceptions[tag_ore_name] == nil then
 					tag.destroy()
 				end
 			end

--- a/english.lua
+++ b/english.lua
@@ -126,7 +126,7 @@ return {
 	["infinite-ore-zinc"]="Zinc",
 	["oil-sand"]="Oil sand",
 	["infinite-oil-sand"]="Oil sand",
-	
+
 		-- Krastorio
 	["imersite"]="Raw Imersite",
 	["mineral-water"]="Mineral Water",


### PR DESCRIPTION
For example: to specify to delete everything except Copper ore and Stone, use
/resourcemarker delete,Stone,Copper ore

This slightly messed up the retag command because the clear_map_tags_and_data function can no longer take in nil arguments, but i "fixed" that by removing the nil argument. You could probably use this to specify what tags to delete (have a third argument to specify "only" or "except" and change the if tag_exceptions[] == nil to tag_exceptions[] ~= nil based on that input), but i don't need to do that for my game right now so i aint doing it.